### PR TITLE
Removed pinned tomcat version that now generates a CVE.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,7 +222,6 @@ ext {
 }
 
 ext['snakeyaml.version'] = '2.0'
-ext['tomcat.version'] = '10.1.54'
 dependencyManagement {
   imports {
     mavenBom 'org.testcontainers:testcontainers-bom:2.0.5'


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
